### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/kaoken/veritransjp-airweb-php-laravel",
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "~5.5"
+        "laravel/framework": "5.5.*"
     },
     "authors": [
         {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.